### PR TITLE
Store parameters in project

### DIFF
--- a/mask/aeag_mask.py
+++ b/mask/aeag_mask.py
@@ -56,7 +56,8 @@ def do(crs=None, poly=None, name=None):
     # crs = QgsCoordinateReferenceSystem
     # poly = list of geometries
     global aeag_mask_instance
-    aeag_mask_instance.apply_mask_parameters(crs,poly,name)
+    this = aeag_mask_instance
+    this.layer = this.apply_mask_parameters(this.layer, this.parameters, crs, poly, name)
 
 def is_in_qgis_core( sym ):
     import qgis.core
@@ -209,7 +210,8 @@ class aeag_mask(QObject):
 
     def on_project_open( self, dom ):
         self.layer, self.parameters = self.load_from_project()
-        self.layer = self.apply_mask_parameters( self.layer, self.parameters, dest_crs = None, poly = None, name = self.layer.name() )        
+        if self.layer is not None:
+            self.layer = self.apply_mask_parameters( self.layer, self.parameters, dest_crs = None, poly = None, name = self.layer.name() )        
 
     def on_current_layer_changed( self, layer ):
         if self.layer is None:

--- a/mask/mask_parameters.py
+++ b/mask/mask_parameters.py
@@ -36,6 +36,7 @@ class MaskParameters:
         # layers (list of id) where labeling has to be limited
         self.limited_layers = []
 
+        self.orig_geometry = None
         self.geometry = None
 
     def serialize( self, with_style = True ):
@@ -54,7 +55,9 @@ class MaskParameters:
                              self.limited_layers,
                              style,
                              self.polygon_mask_method,
-                             self.line_mask_method])
+                             self.line_mask_method,
+                             [ g.asWkb() for g in self.orig_geometry ] if self.orig_geometry is not None else None,
+                             self.geometry.asWkb() if self.geometry is not None else None])
 
     def unserialize( self, st ):
         (self.do_buffer,
@@ -68,10 +71,24 @@ class MaskParameters:
          self.limited_layers,
          style,
          self.polygon_mask_method,
-         self.line_mask_method
+         self.line_mask_method,
+         orig_geom,
+         geom
          ) = pickle.loads( st )
+        self.style = None
+        self.geometry = None
         if style is not None:
             self.style = style
+        if geom is not None:
+            self.geometry = QgsGeometry()
+            self.geometry.fromWkb( geom )
+        if orig_geom is not None:
+            gl = []
+            for g in orig_geom:
+                geo = QgsGeometry()
+                geo.fromWkb( g )
+                gl.append( geo )
+            self.orig_geometry = gl
 
     def load_from_layer( self, layer ):
         # try to load parameters from a mask layer
@@ -124,3 +141,17 @@ class MaskParameters:
             ok = pr.changeAttributeValues( { fet.id() : { 0 : serialized } } )
             ok = pr.changeGeometryValues( { fet.id() : self.geometry } )
         layer.updateExtents()
+
+    def save_to_project( self ):
+        serialized = base64.b64encode( self.serialize() )
+        QgsProject.instance().writeEntry( "Mask", "parameters", serialized )
+        return True
+
+    def load_from_project( self ):
+        st, ok = QgsProject.instance().readEntry( "Mask", "parameters" )
+        if st == '':
+            return False
+
+        self.unserialize( base64.b64decode(st) )
+        return True
+


### PR DESCRIPTION
Don't use the mask layer to store parameters of the mask anymore. Use properties of the project.
Don't use a separate layer for the atlas preview anymore.
Needs some more tests. Feedback welcomed