### PR TITLE
Fixes

### DIFF
--- a/mask/aeag_mask.py
+++ b/mask/aeag_mask.py
@@ -297,7 +297,7 @@ class aeag_mask(QObject):
         for composer_map in compo.composerMapItems():
             if composer_map not in self.composers[compo]:
                 self.composers[compo].append(composer_map)
-                composer_map.preparedForAtlas.connect( lambda c=compo: self.on_prepared_for_atlas(c, composer_map) )
+                composer_map.preparedForAtlas.connect( lambda this=self,c=compo: this.on_prepared_for_atlas(c, composer_map) )
                 break
 
     def on_composer_item_removed( self, compo, _ ):
@@ -340,8 +340,12 @@ class aeag_mask(QObject):
         if not self.layer:
             return
 
-        if hasattr(compo.atlasComposition(), "currentGeometry"): #qgis 2.12
+        if hasattr(compo.atlasComposition(), "currentGeometry"): #qgis 2.14
             geom = compo.atlasComposition().currentGeometry()
+        elif hasattr(compo, "createExpressionContext"): #qgis 2.12
+            ctxt = compo.createExpressionContext()
+            e = QgsExpression("@atlas_geometry")
+            geom = e.evaluate(ctxt)
         else:
             geom = QgsExpression.specialColumn("$atlasgeometry")
 

--- a/mask/aeag_mask.py
+++ b/mask/aeag_mask.py
@@ -66,18 +66,37 @@ def is_in_qgis_core( sym ):
 
 class MaskGeometryFunction( QgsExpression.Function ):
     def __init__( self, mask ):
-        QgsExpression.Function.__init__( self, "$mask_geometry", 0, "Python", "Geometry of the current mask." )
+        QgsExpression.Function.__init__(self, "$mask_geometry", 0, "Python", self.tr("""<h1>$mask_geometry</h1>
+Variable filled by mask plugin.<br/>
+When mask has been triggered on some polygon, mask_geometry is filled with the mask geometry and can be reused for expression/python calculation. in_mask variable uses that geometry to compute a boolean.
+<h2>Return value</h2>
+The geometry of the current mask
+        """))
         self.mask = mask
 
-    def func( self, values, feature, parent ):
+    def tr(self, message):
+        return QCoreApplication.translate('MaskGeometryFunction', message)
+
+    def func(self, values, feature, parent):
         return self.mask.mask_geometry()[0]
 
 class InMaskFunction( QgsExpression.Function ):
     def __init__( self, mask ):
-        QgsExpression.Function.__init__( self, "in_mask", 1, "Python", "Test whether the current geometry is inside the current mask geometry." )
+        QgsExpression.Function.__init__(self, "in_mask", 1, "Python", self.tr("""<h1>in_mask function</h1>
+Expression function added by mask plugin. Returns true if current feature crosses mask geometry.<br/>
+The spatial expression to use is set from the mask UI button (exact, fast using centroids, intermediate using point on surface).<br/>
+in_mask takes a CRS EPSG code as first parameter, which is the CRS code of the evaluated features.<br/>
+It can be used to filter labels only in that area, or since QGIS 2.13, legend items only visible in mask area.<br/> 
+<h2>Return value</h2>
+true/false (0/1)<br/>
+<h2>Usage</h2>
+in_mask(2154)"""))
         self.mask = mask
 
-    def func( self, values, feature, parent ):
+    def tr(self, message):
+        return QCoreApplication.translate('InMaskFunction', message)
+
+    def func(self, values, feature, parent):
         return self.mask.in_mask( feature, values[0] )
 
 class aeag_mask(QObject):

--- a/mask/doc/en/tips.html
+++ b/mask/doc/en/tips.html
@@ -10,7 +10,7 @@
   has been added to the legend filter tool, allowing to specify an expression. A symbol will be part of
   the legend only if at least one of its features make the boolean expression evaluated to true.</p>
 <p>That can especially be used to filter out features that are not visible inside the mask by using
-  the function <tt>in_mask()</tt>. The first argument must be the EPSG code of the target CRS of the evaluted features.
+  the function <tt>in_mask()</tt>. The first argument must be the EPSG code of the target CRS of the evaluated features.
   For example <tt>in_mask(2154)</tt> for a French Lambert 93.</p>
 <br/>
 <center><img src="legend_inmask.png"/></center>

--- a/mask/mask_fr.ts
+++ b/mask/mask_fr.ts
@@ -1,6 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS><TS version="2.0" language="fr_FR" sourcelanguage="">
 <context>
+    <name>InMaskFunction</name>
+    <message>
+        <location filename="aeag_mask.py" line="85"/>
+        <source>&lt;h1&gt;in_mask function&lt;/h1&gt;
+Expression function added by mask plugin. Returns true if current feature crosses mask geometry.&lt;br/&gt;
+The spatial expression to use is set from the mask UI button (exact, fast using centroids, intermediate using point on surface).&lt;br/&gt;
+in_mask takes a CRS EPSG code as first parameter, which is the CRS code of the evaluated features.&lt;br/&gt;
+It can be used to filter labels only in that area, or since QGIS 2.13, legend items only visible in mask area.&lt;br/&gt; 
+&lt;h2&gt;Return value&lt;/h2&gt;
+true/false (0/1)&lt;br/&gt;
+&lt;h2&gt;Usage&lt;/h2&gt;
+in_mask(2154)</source>
+        <translation>&lt;h1&gt;Fonction in_mask&lt;/h1&gt;
+Fonction ajoutée par le plugin Mask. Renvoie vrai si l&apos;entité courante intersecte la géométrie de masque.&lt;br/&gt;
+Les options de l&apos;intersection spatiale (exacte, utilisant les centroïdes ou un point sur la surface, etc.) peuvent être réglées par la boite de dialogue de configuration du plugin Mask.&lt;br/&gt;
+in_mask prend un code EPSG de projection en premier paramètre qui représente la projection de l&apos;entité courante.&lt;br/&gt;
+Cette fonction peut être utilisée pour filtrer des étiquettes ou, à partir de QGIS 2.13, pour filtrer des élements de légende.&lt;br/&gt; 
+&lt;h2&gt;Valeur retournée&lt;/h2&gt;
+vrai/faux (0/1)&lt;br/&gt;
+&lt;h2&gt;Utilisation&lt;/h2&gt;
+in_mask(2154)</translation>
+    </message>
+</context>
+<context>
     <name>LayerListWidget</name>
     <message>
         <location filename="ui_layer_list.ui" line="36"/>
@@ -121,32 +145,32 @@
         <translation>...</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="50"/>
+        <location filename="maindialog.py" line="48"/>
         <source>Save as defaults</source>
         <translation>Sauver comme valeurs par défaut</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="54"/>
+        <location filename="maindialog.py" line="52"/>
         <source>Load defaults</source>
         <translation>Charger les valeurs par défaut</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="283"/>
+        <location filename="maindialog.py" line="287"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="283"/>
+        <location filename="maindialog.py" line="287"/>
         <source>Some layer have rendering simplification turned on, which is not compatible with the labeling filtering you choose. Force simplification disabling ?</source>
         <translation>La simplification à la volée est activée sur certaines couches, ce qui n&apos;est pas compatible avec la méthode de filtrage des étiquettes choisie. Désactiver la simplification à la volée sur ces couches ?</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="75"/>
+        <location filename="maindialog.py" line="73"/>
         <source>Create a mask</source>
         <translation>Créer un masque</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="77"/>
+        <location filename="maindialog.py" line="75"/>
         <source>Update the current mask</source>
         <translation>Mettre à jour le masque existant</translation>
     </message>
@@ -191,90 +215,112 @@
         <translation>Est-ce que la couche de masque doit être sauvegardée. Par défaut une couche mémoire est créée.</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="173"/>
+        <location filename="maindialog.py" line="171"/>
         <source>Select a filename to save the mask layer to</source>
         <translation>Sélectionnez un nom de fichier pour sauvegarder la couche de masque</translation>
     </message>
     <message>
-        <location filename="maindialog.py" line="46"/>
+        <location filename="maindialog.py" line="44"/>
         <source>Tips</source>
         <translation>Astuces</translation>
+    </message>
+    <message>
+        <location filename="ui_plugin_mask.ui" line="253"/>
+        <source>&apos;&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MaskGeometryFunction</name>
+    <message>
+        <location filename="aeag_mask.py" line="69"/>
+        <source>&lt;h1&gt;$mask_geometry&lt;/h1&gt;
+Variable filled by mask plugin.&lt;br/&gt;
+When mask has been triggered on some polygon, mask_geometry is filled with the mask geometry and can be reused for expression/python calculation. in_mask variable uses that geometry to compute a boolean.
+&lt;h2&gt;Return value&lt;/h2&gt;
+The geometry of the current mask
+        </source>
+        <translation>&lt;h1&gt;$mask_geometry&lt;/h1&gt;
+Variable renseignée par le plugin Mask.&lt;br/&gt;
+Quand le mask a été créé sur un polygone, la variable $mask_geometry représente la géométrie de ce polygone et peut être réutilisée dans une expression. La fonction in_mask() utilise cette géométrie pour son calcul.
+&lt;h2&gt;Valeur de retour&lt;/h2&gt;
+La géométrie courante du masque</translation>
     </message>
 </context>
 <context>
     <name>aeag_mask</name>
     <message>
-        <location filename="aeag_mask.py" line="513"/>
+        <location filename="aeag_mask.py" line="543"/>
         <source>Mask plugin error</source>
         <translation>Erreur du plugin Mask</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="513"/>
+        <location filename="aeag_mask.py" line="543"/>
         <source>No polygon selection !</source>
         <translation>Aucune sélection !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="546"/>
+        <location filename="aeag_mask.py" line="576"/>
         <source>Create a mask</source>
         <translation>Créer un masque</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="544"/>
+        <location filename="aeag_mask.py" line="574"/>
         <source>Update the current mask</source>
         <translation>Mettre à jour le masque existant</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="464"/>
+        <location filename="aeag_mask.py" line="494"/>
         <source>Problem saving the mask layer</source>
         <translation>Problème lors de la sauvegarde de la couche masque</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="446"/>
+        <location filename="aeag_mask.py" line="476"/>
         <source>Driver not found !</source>
         <translation>Pilote introuvable !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="448"/>
+        <location filename="aeag_mask.py" line="478"/>
         <source>Cannot create data source !</source>
         <translation>Impossible de créer la source de données !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="450"/>
+        <location filename="aeag_mask.py" line="480"/>
         <source>Cannot create layer !</source>
         <translation>Impossible de créer la couche !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="452"/>
+        <location filename="aeag_mask.py" line="482"/>
         <source>Attribute type unsupported !</source>
         <translation>Type d&apos;attribut non supporté !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="454"/>
+        <location filename="aeag_mask.py" line="484"/>
         <source>Attribute creation failed !</source>
         <translation>Echec de création d&apos;attribut !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="456"/>
+        <location filename="aeag_mask.py" line="486"/>
         <source>Projection error !</source>
         <translation>Erreur de projection !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="458"/>
+        <location filename="aeag_mask.py" line="488"/>
         <source>Feature write failed !</source>
         <translation>Echec d&apos;écriture !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="460"/>
+        <location filename="aeag_mask.py" line="490"/>
         <source>Invalid layer !</source>
         <translation>Couche invalide !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="169"/>
+        <location filename="aeag_mask.py" line="188"/>
         <source>About</source>
         <translation>A propos</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="171"/>
+        <location filename="aeag_mask.py" line="190"/>
         <source>Documentation</source>
         <translation>Documentation</translation>
     </message>

--- a/mask/mask_fr.ts
+++ b/mask/mask_fr.ts
@@ -250,67 +250,67 @@ La géométrie courante du masque</translation>
 <context>
     <name>aeag_mask</name>
     <message>
-        <location filename="aeag_mask.py" line="543"/>
+        <location filename="aeag_mask.py" line="554"/>
         <source>Mask plugin error</source>
         <translation>Erreur du plugin Mask</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="543"/>
+        <location filename="aeag_mask.py" line="554"/>
         <source>No polygon selection !</source>
         <translation>Aucune sélection !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="576"/>
+        <location filename="aeag_mask.py" line="587"/>
         <source>Create a mask</source>
         <translation>Créer un masque</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="574"/>
+        <location filename="aeag_mask.py" line="585"/>
         <source>Update the current mask</source>
         <translation>Mettre à jour le masque existant</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="494"/>
+        <location filename="aeag_mask.py" line="505"/>
         <source>Problem saving the mask layer</source>
         <translation>Problème lors de la sauvegarde de la couche masque</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="476"/>
+        <location filename="aeag_mask.py" line="487"/>
         <source>Driver not found !</source>
         <translation>Pilote introuvable !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="478"/>
+        <location filename="aeag_mask.py" line="489"/>
         <source>Cannot create data source !</source>
         <translation>Impossible de créer la source de données !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="480"/>
+        <location filename="aeag_mask.py" line="491"/>
         <source>Cannot create layer !</source>
         <translation>Impossible de créer la couche !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="482"/>
+        <location filename="aeag_mask.py" line="493"/>
         <source>Attribute type unsupported !</source>
         <translation>Type d&apos;attribut non supporté !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="484"/>
+        <location filename="aeag_mask.py" line="495"/>
         <source>Attribute creation failed !</source>
         <translation>Echec de création d&apos;attribut !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="486"/>
+        <location filename="aeag_mask.py" line="497"/>
         <source>Projection error !</source>
         <translation>Erreur de projection !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="488"/>
+        <location filename="aeag_mask.py" line="499"/>
         <source>Feature write failed !</source>
         <translation>Echec d&apos;écriture !</translation>
     </message>
     <message>
-        <location filename="aeag_mask.py" line="490"/>
+        <location filename="aeag_mask.py" line="501"/>
         <source>Invalid layer !</source>
         <translation>Couche invalide !</translation>
     </message>
@@ -323,6 +323,11 @@ La géométrie courante du masque</translation>
         <location filename="aeag_mask.py" line="190"/>
         <source>Documentation</source>
         <translation>Documentation</translation>
+    </message>
+    <message>
+        <location filename="aeag_mask.py" line="196"/>
+        <source>Restore mask from selected layer</source>
+        <translation>Récupérer les paramètres depuis la couche sélectionnée</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
* Fix atlas geometry access for QGIS 2.12
* Add an option to restore mask parameters from a layer (to restore parameters from a older version)
* Add doc for function expressions (with fr translations)